### PR TITLE
Update dual_hub_Branch2_SD-WAN_Overlay.txt

### DIFF
--- a/4D-SDWAN/Dual hub/Branches/dual_hub_Branch2_SD-WAN_Overlay.txt
+++ b/4D-SDWAN/Dual hub/Branches/dual_hub_Branch2_SD-WAN_Overlay.txt
@@ -282,7 +282,6 @@ config router bgp
 	    	set soft-reconfiguration enable
         next
     end
-    end
     config network
         edit 1
             set prefix 10.1.4.0 255.255.255.0


### PR DESCRIPTION
The original config failed in FortiManager. Removing a duplicate "end" line fixes it. @ckeighley